### PR TITLE
Add version stamping via govvv

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,13 +4,14 @@ go: go1.6
 install:
 - go get -u github.com/golang/lint/golint
 - go get -u github.com/mitchellh/gox
+- go get -u github.com/ahmetalpbalkan/govvv
 script:
 - test -z "$(gofmt -s -l -w $(find . -type f -name '*.go' -not -path './vendor/*')
   | tee /dev/stderr)"
 - test -z "$(golint . | tee /dev/stderr)"
 - test -z "$(go vet -v $(go list ./... | grep -v '/vendor/') | tee /dev/stderr)"
 - go list ./... | grep -v '/vendor/' | xargs go test -v -cover
-- gox -os="linux darwin windows" -arch="amd64"
+- gox -gocmd=govvv -os="linux darwin windows" -arch="amd64"
 deploy:
   provider: releases
   api_key:

--- a/main.go
+++ b/main.go
@@ -9,8 +9,9 @@ import (
 	"github.com/codegangsta/cli"
 )
 
-const (
-	version = "1.0.0-beta1"
+var (
+	// GitSummary contains version info, provided by govvv at compile time
+	GitSummary string
 )
 
 func init() {
@@ -67,7 +68,7 @@ var (
 func main() {
 	app := cli.NewApp()
 	app.Name = "azure-extensions-cli"
-	app.Version = version
+	app.Version = GitSummary
 	app.Usage = "This tool is designed for Microsoft internal extension publishers to release, update and manage Virtual Machine extensions."
 	app.Authors = []cli.Author{{Name: "Ahmet Alp Balkan", Email: "ahmetb at microsoft döt com"}}
 	app.Commands = []cli.Command{


### PR DESCRIPTION
Parse version info from git tree of the build env instead of updating on each release (which already went out of date once). cc: @paulmey PTAL