### PR TITLE
Allow sovereign clouds to upload the extension pkg

### DIFF
--- a/main.go
+++ b/main.go
@@ -5,6 +5,7 @@ import (
 	"os"
 
 	"github.com/Azure/azure-sdk-for-go/management"
+	"github.com/Azure/azure-sdk-for-go/storage"
 	log "github.com/Sirupsen/logrus"
 	"github.com/codegangsta/cli"
 )
@@ -32,6 +33,11 @@ var (
 		Usage:  "Azure Management URL for a non-public Azure cloud",
 		Value:  management.DefaultAzureManagementURL,
 		EnvVar: "MANAGEMENT_URL"}
+	flStorageRealm = cli.StringFlag{
+		Name:   "storage-base-url",
+		Usage:  "Azure Storage base URL",
+		Value:  storage.DefaultBaseURL,
+		EnvVar: "STORAGE_BASE_URL"}
 	flSubsID = cli.StringFlag{
 		Name:   "subscription-id",
 		Usage:  "Subscription ID for the publisher subscription",
@@ -79,8 +85,8 @@ func main() {
 			Usage:  "Creates an XML file used to publish or update extension.",
 			Action: newExtensionManifest,
 			Flags: []cli.Flag{
-				flMgtURL, flSubsID, flSubsCert, flPackage, flStorageAccount,
-				flNamespace, flName, flVersion,
+				flMgtURL, flSubsID, flSubsCert, flPackage, flStorageRealm,
+				flStorageAccount, flNamespace, flName, flVersion,
 				cli.StringFlag{
 					Name:  "label",
 					Usage: "Human readable name of the extension"},

--- a/manifest.go
+++ b/manifest.go
@@ -10,6 +10,7 @@ import (
 
 func newExtensionManifest(c *cli.Context) {
 	cl := mkClient(checkFlag(c, flMgtURL.Name), checkFlag(c, flSubsID.Name), checkFlag(c, flSubsCert.Name))
+	storageRealm := checkFlag(c, flStorageRealm.Name)
 	storageAccount := checkFlag(c, flStorageAccount.Name)
 	extensionPkg := checkFlag(c, flPackage.Name)
 
@@ -36,7 +37,7 @@ func newExtensionManifest(c *cli.Context) {
 	}
 
 	// Upload extension blob
-	blobURL, err := uploadBlob(cl, storageAccount, extensionPkg)
+	blobURL, err := uploadBlob(cl, storageRealm, storageAccount, extensionPkg)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/publish.go
+++ b/publish.go
@@ -83,7 +83,7 @@ func updateExtension(c *cli.Context) {
 	}
 }
 
-func uploadBlob(cl ExtensionsClient, storageAccount, packagePath string) (string, error) {
+func uploadBlob(cl ExtensionsClient, storageRealm, storageAccount, packagePath string) (string, error) {
 	// Fetch keys for storage account
 	svc := storageservice.NewClient(cl.client)
 	keys, err := svc.GetStorageServiceKeys(storageAccount)
@@ -104,7 +104,7 @@ func uploadBlob(cl ExtensionsClient, storageAccount, packagePath string) (string
 	defer pkg.Close()
 
 	// Upload blob
-	sc, err := storage.NewBasicClient(storageAccount, keys.PrimaryKey)
+	sc, err := storage.NewClient(storageAccount, keys.PrimaryKey, storageRealm, storage.DefaultAPIVersion, true)
 	if err != nil {
 		return "", fmt.Errorf("Could not create storage client: %v", err)
 	}


### PR DESCRIPTION
Just needed this feature to upload extension package to a sovereign cloud via `new-extension-manifest` subcommand.

cc:@boumenot 