### PR TITLE
No HTTP retries.

### DIFF
--- a/vendor/github.com/Azure/azure-sdk-for-go/management/http.go
+++ b/vendor/github.com/Azure/azure-sdk-for-go/management/http.go
@@ -77,7 +77,7 @@ func (client client) sendAzureRequest(method, url, contentType string, data []by
 		return nil, err
 	}
 
-	response, err := client.sendRequest(httpClient, url, method, contentType, data, 5)
+	response, err := client.sendRequest(httpClient, url, method, contentType, data, 0)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
The SDK hard codes the number of retries to five, and there is no way to
control this value.  The image APIs generally return failures because
they are "busy."  The SDK ends up sending five requests in quick
succession, which just hammers the server unnecessarily. Because there
is not way to control the value and because it is more likely to fail I
set the number of retries to zero.