### PR TITLE
Normalize public cloud region names

### DIFF
--- a/promote.go
+++ b/promote.go
@@ -15,8 +15,10 @@ func promoteToRegions(c *cli.Context) {
 		return
 	}
 
+	normalizedRegions := normalizeRegionList(regions)
+
 	if err := promoteExtension(c, func() (extensionManifest, error) {
-		return newExtensionImageManifest(checkFlag(c, flManifest.Name), regions)
+		return newExtensionImageManifest(checkFlag(c, flManifest.Name), normalizedRegions)
 	}); err != nil {
 		log.Fatal(err)
 	}

--- a/regions.go
+++ b/regions.go
@@ -1,0 +1,111 @@
+package main
+
+import "strings"
+
+var (
+	// Region names differ between Service Management and Resource Manager.
+	// This is an opportunity for customers to make mistakes, and not know
+	// how to fix them.  This is bad. This is a brute force attempt to
+	// reconcile the possible mistakes customer could make and fix them.
+	//
+	// The customer's input is always normalized by
+	//
+	//  1. region.ToLower()
+	//  2. region.Replace(' ', '')
+	//
+	// e.g. South Central US -> southcentralus
+	//
+	// The value southcentralus is then looked up in a dictionary, and the
+	// appropriate Service Management region is returned (South Central US).
+	// If the customer's region does not exist in the dictionary, then the
+	// customer's region is used.  The number of Azure regions is growing
+	// over time, so this code may become out of date with reality.
+	regionMap = map[string]string{
+		// Simplest translation (remove whitespace, and lower case)
+		//  - This is sufficient to map between SM and RM.
+		"australiaeast":      "Australia East",
+		"australiasoutheast": "Australia Southeast",
+		"brazilsouth":        "Brazil South",
+		"canadacentral":      "Canada Central",
+		"canadaeast":         "Canada East",
+		"centralindia":       "Central India",
+		"centralus":          "Central US",
+		"centraluseuap":      "Central US EUAP",
+		"eastasia":           "East Asia",
+		"eastus":             "East US",
+		"eastus2":            "East US 2",
+		"eastus2euap":        "East US 2 EUAP",
+		"japaneast":          "Japan East",
+		"japanwest":          "Japan West",
+		"koreacentral":       "Korea Central",
+		"koreasouth":         "Korea South",
+		"northcentralus":     "North Central US",
+		"northeurope":        "North Europe",
+		"southcentralus":     "South Central US",
+		"southeastasia":      "Southeast Asia",
+		"southindia":         "South India",
+		"uknorth":            "UK North",
+		"uksouth":            "UK South",
+		"uksouth2":           "UK South 2",
+		"ukwest":             "UK West",
+		"westcentralus":      "West Central US",
+		"westeurope":         "West Europe",
+		"westindia":          "West India",
+		"westus":             "West US",
+		"westus2":            "West US 2",
+
+		// Swap direction and country, e.g. UK South -> South UK
+		"asiaeast":           "East Asia",
+		"asiasoutheast":      "Southeast Asia",
+		"centralcanada":      "Canada Central",
+		"centralkorea":       "Korea Central",
+		"eastaustralia":      "Australia East",
+		"eastcanada":         "Canada East",
+		"eastjapan":          "Japan East",
+		"indiacentral":       "Central India",
+		"indiasouth":         "South India",
+		"indiawest":          "West India",
+		"northuk":            "UK North",
+		"southbrazil":        "Brazil South",
+		"southeastaustralia": "Australia Southeast",
+		"southkorea":         "Korea South",
+		"southuk":            "UK South",
+		"southuk2":           "UK South 2",
+		"westjapan":          "Japan West",
+		"westuk":             "UK West",
+
+		// Weirdness where direction/country is already reversed, so reverse
+		// the other way.
+		"europenorth ":   "North Europe",
+		"europewest":     "West Europe",
+		"uscentral":      "Central US",
+		"uscentraleuap":  "Central US EUAP",
+		"useast":         "East US",
+		"useast2":        "East US 2",
+		"useast2euap":    "East US 2 EUAP",
+		"usnorthcentral": "North Central US",
+		"ussouthcentral": "South Central US",
+		"uswest":         "West US",
+		"uswest2":        "West US 2",
+		"uswestcentral":  "West Central US",
+	}
+)
+
+func normalizeRegionList(regions []string) []string {
+	normalizedRegions := make([]string, len(regions))
+	for i := range regions {
+		n := normalizeRegionName(regions[i])
+		if x, ok := regionMap[n]; ok {
+			normalizedRegions[i] = x
+		} else {
+			normalizedRegions[i] = regions[i]
+		}
+	}
+
+	return normalizedRegions
+}
+
+func normalizeRegionName(region string) string {
+	lowered := strings.ToLower(region)
+	return strings.Replace(lowered, " ", "", -1)
+}

--- a/regions_test.go
+++ b/regions_test.go
@@ -1,0 +1,69 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestNormalizeRegion(t *testing.T) {
+	if normalizeRegionName("South Central US") != "southcentralus" {
+		t.Error("Failed to normalize 'South Central US'")
+	}
+
+	if normalizeRegionName("southcentralus") != "southcentralus" {
+		t.Error("Failed to normalize 'southcentralus'")
+	}
+}
+
+func TestRegionIsExact(t *testing.T) {
+	testRegions := []string{
+		"South Central US",
+	}
+
+	regions := normalizeRegionList(testRegions)
+	if len(regions) != 1 {
+		t.Fatalf("There should be exactly one region.")
+	}
+
+	if strings.Compare("South Central US", regions[0]) != 0 {
+		t.Fatalf("Expected the region to by \"South Central US\", but got %q", regions[0])
+	}
+}
+
+func TestRegionMustNormalize(t *testing.T) {
+	testRegions := []string{
+		"southcentralus",
+		"NORTH CENTRAL US",
+		"uksouth",
+	}
+
+	regions := normalizeRegionList(testRegions)
+	if len(regions) != 3 {
+		t.Fatalf("There should be exactly three regions.")
+	}
+
+	if strings.Compare("South Central US", regions[0]) != 0 {
+		t.Fatalf("Expected the region to by \"South Central US\", but got %q", regions[0])
+	}
+	if strings.Compare("North Central US", regions[1]) != 0 {
+		t.Fatalf("Expected the region to by \"North Central US\", but got %q", regions[1])
+	}
+	if strings.Compare("UK South", regions[2]) != 0 {
+		t.Fatalf("Expected the region to by \"UK South\", but got %q", regions[2])
+	}
+}
+
+func TestUnrecognizedRegionIsPassed(t *testing.T) {
+	testRegions := []string{
+		"Candy Land East",
+	}
+
+	regions := normalizeRegionList(testRegions)
+	if len(regions) != 1 {
+		t.Fatalf("There should be exactly one region.")
+	}
+
+	if strings.Compare("Candy Land East", regions[0]) != 0 {
+		t.Fatalf("Expected the region to by \"Candy Land East\", but got %q", regions[0])
+	}
+}


### PR DESCRIPTION
Region names are hard enough to get right that supporting the a few
different permutations should be the norm.  The following region name
forms are now supported

 * UK South
 * South UK
 * uksouth
 * southuk

Spacing and capitalization are no longer important.  Azure use of
direction and country or country and direction are similarly handled.

Closes #13